### PR TITLE
ci(commitlint): add proactive scopes to prevent future timing races

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -25,8 +25,11 @@
       2,
       "always",
       [
+        "admission",
+        "api",
         "chart",
         "ci",
+        "config",
         "controller",
         "coverage",
         "deps",
@@ -35,9 +38,12 @@
         "helm",
         "image",
         "lua",
+        "nginx",
         "release",
         "security",
-        "test"
+        "template",
+        "test",
+        "webhook"
       ]
     ],
     "subject-case": [


### PR DESCRIPTION
## Summary
- Add anticipated scopes to commitlint config to prevent future timing races with automation
- Scopes added: `admission`, `api`, `config`, `nginx`, `template`, `webhook`

## Motivation
Based on flaky test investigation, the pre-commit workflow had a timing race where the bot would create commits with new scopes (like `test`) before adding them to the commitlint config. This change proactively adds scopes that might be needed in the future to prevent similar issues.

## Changes
- `.commitlintrc.json`: Added 6 new scopes alphabetically

## Test Plan
- CI will validate pre-commit hooks pass