### PR TITLE
build(deps): enable Renovate tracking for upstream NGINX version

### DIFF
--- a/images/nginx/rootfs/build.sh
+++ b/images/nginx/rootfs/build.sh
@@ -18,6 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# renovate: datasource=github-releases depName=nginx/nginx versioning=semver
 export NGINX_VERSION=1.27.1
 
 # Check for recent changes: https://github.com/vision5/ngx_devel_kit/compare/v0.3.3...master

--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
     {
       "customType": "regex",
       "description": "Track inline renovate hints in workflow and config files",
-      "managerFilePatterns": ["/.+\\.ya?ml$/", "/(^|/)Makefile$/"],
+      "managerFilePatterns": ["/.+\\.ya?ml$/", "/(^|/)Makefile$/", "/images/nginx/rootfs/build\\.sh$/"],
       "matchStrings": [
         "#\\srenovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\\n.*?: (?<currentValue>.*)\\n",
         "#\\srenovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\\n.*?=\\s*(?<currentValue>.*)\\n"


### PR DESCRIPTION
## Summary

- Add renovate hint annotation (`# renovate: datasource=github-releases depName=nginx/nginx versioning=semver`) above `NGINX_VERSION` in `images/nginx/rootfs/build.sh`
- Add `build.sh` to the customManager `managerFilePatterns` in `renovate.json` so the regex manager matches shell scripts

## Why

Renovate was unable to track the upstream NGINX version (currently `1.27.1`) because:
1. The `NGINX_VERSION` variable in `build.sh` had no renovate hint annotation
2. The customManager regex only matched `.yaml`/`.yml` and `Makefile` patterns, not `.sh` files

With these changes, Renovate will automatically create PRs when new NGINX releases are published.