### PR TITLE
fix(nginx): update to 1.30.1 stable and fix Renovate version tracking

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,6 +41,7 @@ jobs:
               - 'go.mod'
               - 'go.sum'
               - 'rootfs/**'
+              - 'images/nginx/**'
               - 'test/e2e/**'
               - 'test/e2e-image/**'
               - 'charts/**'

--- a/images/nginx/rootfs/build.sh
+++ b/images/nginx/rootfs/build.sh
@@ -18,8 +18,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# renovate: datasource=github-releases depName=nginx/nginx versioning=semver
-export NGINX_VERSION=1.27.1
+# renovate: datasource=github-releases depName=nginx/nginx extractVersion=^release-(?<version>.*)$ versioning=semver
+export NGINX_VERSION=1.30.1
 
 # Check for recent changes: https://github.com/vision5/ngx_devel_kit/compare/v0.3.3...master
 export NDK_VERSION=v0.3.3

--- a/renovate.json
+++ b/renovate.json
@@ -19,10 +19,11 @@
       "description": "Track inline renovate hints in workflow and config files",
       "managerFilePatterns": ["/.+\\.ya?ml$/", "/(^|/)Makefile$/", "/images/nginx/rootfs/build\\.sh$/"],
       "matchStrings": [
-        "#\\srenovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\\n.*?: (?<currentValue>.*)\\n",
-        "#\\srenovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\\n.*?=\\s*(?<currentValue>.*)\\n"
+        "#\\srenovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( extractVersion=(?<extractVersion>\\S+))?( versioning=(?<versioning>\\S+))?\\n.*?: (?<currentValue>.*)\\n",
+        "#\\srenovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( extractVersion=(?<extractVersion>\\S+))?( versioning=(?<versioning>\\S+))?\\n.*?=\\s*(?<currentValue>.*)\\n"
       ],
-      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
+      "extractVersionTemplate": "{{#if extractVersion}}{{{extractVersion}}}{{/if}}"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
## Summary

- Update NGINX from 1.27.1 to **1.30.1** (current stable release)
- Fix Renovate custom manager to support `extractVersion` field in inline hints
- Add `extractVersion=^release-(?<version>.*)$` to the nginx hint so Renovate can parse GitHub release tags (`release-X.Y.Z` → `X.Y.Z`)

## Problem

Renovate detected `NGINX_VERSION=1.27.1` via the custom regex manager but could not discover newer versions. nginx GitHub releases are tagged as `release-1.30.1` (not plain `1.30.1`), so `versioning=semver` alone failed to match any releases. The custom manager regex also had no support for `extractVersion`, so the hint couldn't be expressed.

## Changes

- **`renovate.json`**: Updated both `matchStrings` to optionally capture `extractVersion`, added `extractVersionTemplate`. Backwards compatible — existing hints without `extractVersion` continue to work.
- **`images/nginx/rootfs/build.sh`**: Added `extractVersion=^release-(?<version>.*)$` to the renovate hint and bumped `NGINX_VERSION` to 1.30.1.

## Test plan

- [x] Verified regex matches all three hint variants (with extractVersion, without, minimal)
- [x] JSON validated
- [ ] Renovate detects the new hint on next run
- [ ] Build succeeds with nginx 1.30.1 (`make image`)