### PR TITLE
fix(release): pass TAG to kube-webhook-certgen publish step

### DIFF
--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -87,6 +87,7 @@ jobs:
             PLATFORMS="${{ env.IMAGE_PLATFORMS }}" \
             REGISTRY="${{ env.IMAGE_REGISTRY }}" \
             NAME=kube-webhook-certgen \
+            TAG="${VERSION}" \
             push
 
       - name: Get Changelog Entry


### PR DESCRIPTION
## Summary

The release workflow publishes `controller` and `kube-webhook-certgen` under inconsistent tag schemes. The chart hardcodes `tag: 2026.5.14` (no `v`), which matches the controller image but not the webhook-certgen image (published as `v2026.5.14`), so fresh upgrades fail with `ImagePullBackOff` on the webhook job.

Root cause: in `.github/workflows/docker_images.yml`, the `Publish controller images` step passes `TAG="${VERSION}"` (where `VERSION` has had its leading `v` stripped), while the `Publish kube-webhook-certgen image` step doesn't pass `TAG` at all and falls back to the contents of `images/kube-webhook-certgen/TAG` — which currently reads `v2026.5.14`.

This PR passes `TAG="${VERSION}"` to the webhook-certgen step so both images publish under the same scheme the chart already expects. Fixes the immediate `2026.5.14` mismatch and prevents the inconsistency from re-emerging on every release.

Fixes #58

## Test plan

- [ ] Cut a new tag and confirm `kube-webhook-certgen` publishes under the un-prefixed version (e.g. `2026.5.15`) matching the controller image
- [ ] Confirm a fresh `helm install` of the published chart no longer hits `ImagePullBackOff` on the admission webhook jobs

I can't run the release pipeline locally, so the test plan is the maintainer's call. The diff itself is symmetric with the controller publish step immediately above it.