### PR TITLE
fix(release): support shallow clones by fetching full history before git-cliff

### DIFF
--- a/.ci/generate-release-notes.sh
+++ b/.ci/generate-release-notes.sh
@@ -8,6 +8,12 @@ NOTES_FILE="/tmp/release-notes.md"
 REGISTRY="ghcr.io/forkline/ingress-nginx"
 
 if [ -z "$PREV_VERSION" ]; then
+    if git rev-parse --is-shallow-repository 2>/dev/null | grep -q "true"; then
+        git fetch --unshallow --quiet 2>/dev/null || true
+    fi
+    if [ -z "$(git tag -l)" ]; then
+        git fetch --tags --quiet
+    fi
     PREV_VERSION=$(git tag --sort=-creatordate | grep -v "^${VERSION}$" | head -1)
 fi
 

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -1,7 +1,20 @@
 #!/bin/bash
 set -e
 
-if ! [ "$(git rev-list --count origin/main..HEAD)" -eq 0 ]; then
+ensure_full_history() {
+    if git rev-parse --is-shallow-repository 2>/dev/null | grep -q "true"; then
+        echo "Shallow clone detected. Fetching full history and tags..."
+        git fetch --unshallow --quiet
+    fi
+    if [ -z "$(git tag -l)" ]; then
+        echo "No tags found. Fetching tags..."
+        git fetch --tags --quiet
+    fi
+}
+
+ensure_full_history
+
+if ! [ "$(git rev-list --count origin/main..HEAD 2>/dev/null || echo 1)" -eq 0 ]; then
     echo "There are commits in this branch. Please merge them first."
     echo "CHANGELOG template needs main commit ID."
     exit 1

--- a/.opencode/skills/release/SKILL.md
+++ b/.opencode/skills/release/SKILL.md
@@ -39,14 +39,15 @@ git log --oneline <latest_tag>..HEAD
 ```
 
 This script **automatically**:
-1. Verifies you're on main with no unmerged commits
-2. Computes the new version (`vYYYY.M.D`, auto-incrementing suffix if same-day)
-3. Updates `TAG` file and all image `TAG` files
-4. Updates `NGINX_BASE` reference
-5. Runs `make update-version` (Chart.yaml, values.yaml)
-6. Runs `make update-changelog` (git-cliff from conventional commits)
-7. Updates helm-docs and README Supported Versions table
-8. Creates commit: `release: prepare <version>`
+1. Detects and fixes shallow clones (fetches full history + tags)
+2. Verifies you're on main with no unmerged commits
+3. Computes the new version (`vYYYY.M.D`, auto-incrementing suffix if same-day)
+4. Updates `TAG` file and all image `TAG` files
+5. Updates `NGINX_BASE` reference
+6. Runs `make update-version` (Chart.yaml, values.yaml)
+7. Runs `make update-changelog` (git-cliff from conventional commits)
+8. Updates helm-docs and README Supported Versions table
+9. Creates commit: `release: prepare <version>`
 
 ### Step 2: Push to main
 
@@ -95,11 +96,15 @@ All images are published for `linux/amd64` and `linux/arm64`.
 | Creating git tags manually | `auto-tag.yml` creates signed tags automatically | Just push to main |
 | Running from a feature branch | CHANGELOG generation needs main commit IDs | Checkout main first |
 | Releasing with dirty working tree | Script will fail or produce incomplete release | Commit or stash changes first |
+| Worrying about shallow clones | Script auto-detects and fetches full history | Just run `.ci/release.sh` |
 
 ## Troubleshooting
 
 ### "There are commits in this branch. Please merge them first."
 You're on a branch with unmerged commits. Switch to main and merge first.
+
+### "Shallow clone detected. Fetching full history and tags..."
+The release script detected a shallow clone (e.g. CI with `fetch-depth: 1`). It automatically fetches full history and tags so git-cliff can generate a correct CHANGELOG. No action needed.
 
 ### "Version unchanged. Nothing to do."
 Already released this version today. If you need a same-day re-release, the script auto-increments the suffix (`v2026.5.14-1`, `v2026.5.14-2`, etc.) only if the base tag already exists. Check `cat TAG` to see current version.


### PR DESCRIPTION
## Summary

- The release script (`release.sh`) and release notes generator (`generate-release-notes.sh`) now auto-detect shallow clones (`--depth 1`) and fetch full git history + tags before running `git-cliff` or `git tag` commands
- Without this fix, running `.ci/release.sh` in a CI runner that clones with `fetch-depth: 1` produces an incomplete CHANGELOG (only the latest commit) because `git-cliff` has no history to walk

## Why

When the repo is cloned with `--depth 1`, `git tag -l` returns nothing and `git-cliff $PREV_TAG..HEAD` has no commits to process. The result is a CHANGELOG missing most entries — exactly what happened with `v2026.5.18` on the `release/` branch.

## Changes

| File | Change |
|------|--------|
| `.ci/release.sh` | Added `ensure_full_history()` — unshallows clone + fetches tags if missing |
| `.ci/generate-release-notes.sh` | Same shallow/tag detection before `git tag --sort=-creatordate` |
| `.opencode/skills/release/SKILL.md` | Documented shallow clone auto-handling |

## Testing

- `pre-commit run --all-files` passes (shellcheck, etc.)
- Logic: `git rev-parse --is-shallow-repository` reliably detects shallow clones; `git fetch --unshallow` + `git fetch --tags` restores full history