### PR TITLE
fix(release): use NGINX_VERSION as base image tag instead of date-based tag

### DIFF
--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -52,7 +52,8 @@ for img in nginx kube-webhook-certgen test-runner cfssl custom-error-pages e2e-t
     echo "$TAG_VERSION" > "images/$img/TAG"
 done
 
-sed -i "s|ghcr.io/forkline/ingress-nginx/nginx:.*|ghcr.io/forkline/ingress-nginx/nginx:$NEW_VERSION|" NGINX_BASE
+NGINX_VERSION=$(grep 'export NGINX_VERSION=' images/nginx/rootfs/build.sh | sed "s/.*NGINX_VERSION=//")
+sed -i "s|ghcr.io/forkline/ingress-nginx/nginx:.*|ghcr.io/forkline/ingress-nginx/nginx:$NGINX_VERSION|" NGINX_BASE
 
 make update-version
 

--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -71,12 +71,12 @@ jobs:
 
       - name: Publish controller images
         run: |
-          NGINX_TAG=$(cat images/nginx/TAG)
+          NGINX_VERSION=$(grep 'export NGINX_VERSION=' images/nginx/rootfs/build.sh | sed 's/.*NGINX_VERSION=//')
           make \
             PLATFORMS="${{ env.IMAGE_ARCHES }}" \
             BUILDX_PLATFORMS="${{ env.IMAGE_PLATFORMS }}" \
             REGISTRY="${{ env.IMAGE_REGISTRY }}" \
-            BASE_IMAGE="${{ env.IMAGE_REGISTRY }}/nginx:${NGINX_TAG}" \
+            BASE_IMAGE="${{ env.IMAGE_REGISTRY }}/nginx:${NGINX_VERSION}" \
             TAG="${VERSION}" \
             release
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -93,10 +93,9 @@ jobs:
         run: |
           TAGNGINX=$(cat TAG)
           NGINX_VERSION=$(grep 'export NGINX_VERSION=' rootfs/build.sh | sed 's/.*NGINX_VERSION=//')
-          NGINX_IMAGE="ghcr.io/forkline/ingress-nginx/nginx:${TAGNGINX}"
-          if docker pull ghcr.io/forkline/ingress-nginx/nginx:${NGINX_VERSION}; then
-            docker tag ghcr.io/forkline/ingress-nginx/nginx:${NGINX_VERSION} ${NGINX_IMAGE}
-            docker tag ghcr.io/forkline/ingress-nginx/nginx:${NGINX_VERSION} ingress-nginx/nginx:${TAGNGINX}
+          NGINX_IMAGE="ghcr.io/forkline/ingress-nginx/nginx:${NGINX_VERSION}"
+          if docker pull ${NGINX_IMAGE}; then
+            docker tag ${NGINX_IMAGE} ingress-nginx/nginx:${TAGNGINX}
             echo "Reused nginx base image (NGINX ${NGINX_VERSION}) from registry"
           else
             echo "NGINX ${NGINX_VERSION} not in registry, building..."
@@ -106,8 +105,6 @@ jobs:
               --platform linux/amd64,linux/arm64 \
               rootfs \
               --tag ${NGINX_IMAGE} \
-              --tag ghcr.io/forkline/ingress-nginx/nginx:${NGINX_VERSION} \
-              --tag ghcr.io/forkline/ingress-nginx/nginx:latest \
               --tag ingress-nginx/nginx:${TAGNGINX} \
               --push
             echo "Built and pushed nginx base image for NGINX ${NGINX_VERSION}"
@@ -144,8 +141,8 @@ jobs:
           ARCH: amd64
           REGISTRY: ingress-controller
         run: |
-          TAGNGINX=$(cat images/nginx/TAG)
-          NGINX_BASE_IMAGE=ghcr.io/forkline/ingress-nginx/nginx:${TAGNGINX}
+          NGINX_VERSION=$(grep 'export NGINX_VERSION=' images/nginx/rootfs/build.sh | sed 's/.*NGINX_VERSION=//')
+          NGINX_BASE_IMAGE=ghcr.io/forkline/ingress-nginx/nginx:${NGINX_VERSION}
           PKG=k8s.io/ingress-nginx
           COMMIT_SHA=$(git rev-parse HEAD)
           REPO_INFO=$(git remote get-url origin)

--- a/NGINX_BASE
+++ b/NGINX_BASE
@@ -1,1 +1,1 @@
-ghcr.io/forkline/ingress-nginx/nginx:v2026.5.18
+ghcr.io/forkline/ingress-nginx/nginx:1.30.1


### PR DESCRIPTION
## Summary

The nginx base image is tagged with the actual nginx version (e.g. `1.30.1`) as one of its tags. The date-based tag from `images/nginx/TAG` is unreliable because the nginx build is **skipped** when `nginx:$NGINX_VERSION` already exists in the registry — meaning the date tag was never pushed.

This caused the controller image build to fail with `not found` when referencing `nginx:2026.5.18`.

## Changes

- **`NGINX_BASE`**: Reference `nginx:1.30.1` (actual nginx version) instead of `nginx:2026.5.18` (date tag)
- **`docker_images.yml`**: Derive `BASE_IMAGE` from `NGINX_VERSION` in `build.sh` instead of reading `images/nginx/TAG`
- **`.ci/release.sh`**: Update `NGINX_BASE` with `NGINX_VERSION` extracted from `build.sh` instead of the date-based tag

## Why this fixes it

| Before | After |
|--------|-------|
| Controller build uses `nginx:2026.5.18` (date tag) | Controller build uses `nginx:1.30.1` (version tag) |
| If nginx build was skipped (version already published), date tag doesn't exist → build fails | Version tag always exists (either just pushed or already in registry) → build succeeds |