### PR TITLE
fix(ci): add timeouts to E2E workflow jobs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,6 +26,7 @@ jobs:
   changes:
     name: Detect E2E changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: github.event_name == 'pull_request'
     outputs:
       e2e: ${{ steps.filter.outputs.e2e }}
@@ -52,6 +53,7 @@ jobs:
   build:
     name: Build test images
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: [changes]
     if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.e2e == 'true')
     steps:
@@ -203,6 +205,7 @@ jobs:
   chart-test:
     name: Chart e2e
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: [changes, build]
     if: >-
       always() && (github.event_name != 'pull_request' ||
@@ -230,6 +233,7 @@ jobs:
   kubernetes:
     name: Kubernetes
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     needs: [changes, build]
     if: >-
       always() && (github.event_name != 'pull_request' ||
@@ -293,6 +297,7 @@ jobs:
   kubernetes-chroot:
     name: Kubernetes chroot
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     needs: [changes, build]
     if: >-
       always() && github.event_name != 'pull_request' &&
@@ -371,6 +376,7 @@ jobs:
   e2e-checks-passed:
     name: E2E checks passed
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: [changes, build, chart-test, kubernetes]
     if: >-
       always()


### PR DESCRIPTION
## Summary
- Add `timeout-minutes` to all E2E workflow jobs to prevent indefinite hangs that block the concurrency group and prevent subsequent runs from starting

## Problem
PRs like #78 were blocked from merging because:
1. An E2E Kubernetes job got stuck `in_progress` with no timeout
2. The stuck job blocked the `e2e-${{ github.ref }}` concurrency group
3. Newer E2E runs were stuck in `pending` with 0 jobs
4. No `E2E checks passed` check was ever reported
5. Branch protection required checks that never completed

## Changes
| Job | Timeout |
|---|---|
| `changes` | 5 min |
| `build` | 30 min |
| `chart-test` | 30 min |
| `kubernetes` | 90 min |
| `kubernetes-chroot` | 90 min |
| `e2e-checks-passed` | 5 min |

## Follow-up (repo config)
Branch protection required status checks should be updated to:
- `pre-commit`
- `govulncheck`
- `Go checks passed`
- `E2E checks passed`

Remove individually-skipped checks: `Build binaries`, `Unit tests`, `Verify generated docs`, `golangci-lint`, `Chart e2e`, `Build test images`, `Kubernetes`