### PR TITLE
fix: prevent metrics endpoint exposure when disabled

### DIFF
--- a/cmd/dataplane/main.go
+++ b/cmd/dataplane/main.go
@@ -85,7 +85,9 @@ func main() {
 
 	mux := http.NewServeMux()
 	metrics.RegisterHealthz(nginx.HealthPath, mux)
-	metrics.RegisterMetrics(reg, mux)
+	if conf.EnableMetrics {
+		metrics.RegisterMetrics(reg, mux)
+	}
 
 	go metrics.StartHTTPServer(conf.HealthCheckHost, conf.ListenPorts.Health, mux)
 	go ngx.Start()

--- a/cmd/nginx/main.go
+++ b/cmd/nginx/main.go
@@ -147,7 +147,9 @@ func main() {
 
 	mux := http.NewServeMux()
 	metrics.RegisterHealthz(nginx.HealthPath, mux, ngx)
-	metrics.RegisterMetrics(reg, mux)
+	if conf.EnableMetrics {
+		metrics.RegisterMetrics(reg, mux)
+	}
 
 	_, errExists := os.Stat("/chroot")
 	if errExists == nil {


### PR DESCRIPTION
What this PR does / why we need it:

This PR fixes an issue where the EnableMetrics configuration option was not honored when registering the Prometheus metrics endpoint.

Previously, the /metrics endpoint was always registered regardless of the value of EnableMetrics, causing metrics to remain accessible even when users explicitly disabled metrics collection.

With this change, metrics handlers are only registered when EnableMetrics is set to true, while the health check endpoint remains available as before.